### PR TITLE
Capture stdout to /var/log/coredns.log

### DIFF
--- a/net-dns/coredns/files/coredns.initd
+++ b/net-dns/coredns/files/coredns.initd
@@ -14,7 +14,10 @@ depend() {
 
 start() {
 	ebegin "Starting CoreDNS"
-	start-stop-daemon --background ${command} -- ${command_args}
+	start-stop-daemon \
+		--background ${command} \
+		--stdout /var/log/coredns.log \
+		-- ${command_args}
 	eend $?
 }
 


### PR DESCRIPTION
Coredns logs to stdout per default. Update the init script to capture the output in /var/log/coredns.log